### PR TITLE
fix getJalaliDate() return element

### DIFF
--- a/jalali.js
+++ b/jalali.js
@@ -176,7 +176,7 @@ Date.prototype.getJalaliDate = function() {
 	var gm = this.getMonth();
 	var gy = this.getFullYear();
 	var j = JalaliDate.gregorianToJalali(gy, gm+1, gd);
-	return j[2];
+	return j;
 }
 
 Date.prototype.getJalaliDay = function() {


### PR DESCRIPTION
* getJalaliDate() returns jalaliDate object
 it used to return only "jalali day".

Signed-off-by: Ali Qanavatian <a_good_per@yahoo.com>